### PR TITLE
Apply VS Code style

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  content: [],
+  theme: {
+    extend: {
+      colors: {
+        vscode: {
+          background: '#1e1e1e',
+          panel: '#252526',
+          border: '#333333',
+          accent: '#007acc',
+          text: '#d4d4d4'
+        }
+      },
+      fontFamily: {
+        mono: ['Fira Code', 'monospace']
+      }
+    }
+  }
+};

--- a/webui/css/file_browser.css
+++ b/webui/css/file_browser.css
@@ -125,9 +125,7 @@
 }
 
 #path-text {
-  font-family: 'Roboto Mono', monospace;
-  font-optical-sizing: auto;
-  -webkit-font-optical-sizing: auto;
+  font-family: "Fira Code", monospace;
   opacity: 0.9;
 }
 

--- a/webui/css/messages.css
+++ b/webui/css/messages.css
@@ -12,7 +12,7 @@
   -webkit-transition: all 0.3s ease;
   transition: all 0.3s ease;
   scrollbar-width: thin;
-  scrollbar-color: #555 transparent;
+  scrollbar-color: var(--color-border) transparent;
 }
 
 #chat-history > *:first-child {
@@ -32,17 +32,17 @@
 #chat-history::-webkit-scrollbar-thumb {
   border-radius: 3px;
   box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
-  background-color: #555;
+  background-color: var(--color-border);
   -webkit-transition: background-color var(--transition-speed) ease-in-out;
   transition: background-color var(--transition-speed) ease-in-out;
 }
 
 #chat-history::-webkit-scrollbar-thumb:hover {
-  background-color: #666;
+  background-color: var(--color-border);
 }
 
 #chat-history::-webkit-scrollbar-thumb:active {
-  background-color: #888;
+  background-color: var(--color-border);
 }
 
 /* Message Styles */
@@ -85,9 +85,7 @@
 
 .message-user > div {
   padding-top: var(--spacing-xs);
-  font-family: "Roboto Mono", monospace;
-  font-optical-sizing: auto;
-  -webkit-font-optical-sizing: auto;
+  font-family: "Fira Code", monospace;
   font-size: var(--font-size-small);
 }
 
@@ -292,7 +290,7 @@
   transition: opacity var(--transition-speed) ease-in-out;
   color: inherit;
   font-size: 12px;
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
 }
 
 .copy-button:hover {
@@ -306,7 +304,7 @@
 }
 
 .copy-button.copied {
-  font-family: "Rubik", Arial, Helvetica, sans-serif !important;
+  font-family: "Fira Code", monospace !important;
   opacity: 1 !important;
 }
 

--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -177,8 +177,7 @@
   border: none;
   background-color: transparent;
   color: var(--color-text);
-  font-family: "Roboto Mono", monospace;
-  font-optical-sizing: auto;
+  font-family: "Fira Code", monospace;
   font-size: 0.955rem;
   padding: 1.2rem 1rem;
   resize: none;
@@ -262,7 +261,7 @@
   cursor: pointer;
   border: none;
   font-size: 0.875rem;
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
 }
 
 .btn.slim {

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -51,7 +51,7 @@ select {
   border-radius: 0.25rem;
   background-color: var(--color-background);
   color: var(--color-text);
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   outline: none;
   transition: all 0.3s ease;
 }
@@ -63,7 +63,7 @@ input[type="password"]:focus {
 
 textarea {
   min-height: 100px;
-  font-family: 'Roboto Mono', monospace;
+  font-family: "Fira Code", monospace;
   scroll-behavior: smooth;
   resize: none;
   background-clip: border-box;

--- a/webui/css/toast.css
+++ b/webui/css/toast.css
@@ -2,7 +2,7 @@
   position: relative;
   width: 100%;
   background-color: #333;
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   color: #fff;
   padding: 0.6rem 0.9rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -66,7 +66,7 @@
 .toast__copy {
   background-color: transparent;
   border: none;
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   color: #fff;
   cursor: pointer;
   font-size: 16px;

--- a/webui/index.css
+++ b/webui/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap");
 
 /* Add box-sizing globally for better cross-browser consistency */
 *,
@@ -9,17 +9,17 @@
 
 :root {
   /* Dark mode */
-  --color-background-dark: #131313;
+  --color-background-dark: #1e1e1e;
   --color-text-dark: #d4d4d4;
-  --color-primary-dark: #737a81;
-  --color-secondary-dark: #656565;
-  --color-accent-dark: #cf6679;
-  --color-message-bg-dark: #2d2d2d;
-  --color-message-text-dark: #e0e0e0;
-  --color-panel-dark: #171717;
-  --color-border-dark: #444444a8;
-  --color-input-dark: #131313;
-  --color-input-focus-dark: #101010;
+  --color-primary-dark: #007acc;
+  --color-secondary-dark: #333333;
+  --color-accent-dark: #007acc;
+  --color-message-bg-dark: #252526;
+  --color-message-text-dark: #d4d4d4;
+  --color-panel-dark: #252526;
+  --color-border-dark: #333333;
+  --color-input-dark: #333333;
+  --color-input-focus-dark: #252526;
 
   /* Light mode */
   --color-background-light: #dbdbdb;
@@ -73,7 +73,7 @@ body,
 html {
   background-color: var(--color-background);
   color: var(--color-text);
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   width: 100%;
   height: 100%;
   min-width: 320px !important;
@@ -450,9 +450,7 @@ h4 {
 }
 
 pre {
-  font-family: "Roboto Mono", monospace;
-  font-optical-sizing: auto;
-  -webkit-font-optical-sizing: auto;
+  font-family: "Fira Code", monospace;
   font-size: 0.75rem;
 }
 
@@ -721,9 +719,7 @@ pre {
   border-radius: 8px;
   color: var(--color-text);
   flex-grow: 1;
-  font-family: "Roboto Mono", monospace;
-  font-optical-sizing: auto;
-  -webkit-font-optical-sizing: auto;
+  font-family: "Fira Code", monospace;
   font-size: 0.9rem;
   max-height: 7rem;
   min-height: 3.05rem;
@@ -838,7 +834,7 @@ pre {
   border-radius: var(--spacing-xs);
   cursor: pointer;
   display: inline;
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   font-size: var(--font-size-small);
   opacity: 0.8;
   text-wrap: nowrap;
@@ -1167,7 +1163,7 @@ pre {
   border: none;
   border-radius: 5px;
   color: var(--color-text);
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-family: "Fira Code", monospace;
   font-size: 0.6rem;
   padding: 6px var(--spacing-sm);
   cursor: pointer;
@@ -1608,7 +1604,7 @@ input:checked + .slider:before {
     content: "Copied!";
     position: absolute;
     opacity: 0;
-    font-family: "Rubik", Arial, Helvetica, sans-serif;
+    font-family: "Fira Code", monospace;
     font-size: 0.7rem;
     padding: 6px var(--spacing-sm);
     -webkit-transition: opacity var(--transition-speed) ease-in-out;
@@ -1959,33 +1955,29 @@ a:active {
 }
 
 .tab {
-  padding: 8px 16px;
+  padding: 6px 12px;
   cursor: pointer;
   position: relative;
   color: var(--color-text);
-  border: 2px solid var(--color-border);
-  border-bottom: none;
-  border-radius: 8px 8px 0 0;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 3px 3px 0 0;
   transition: all 0.3s ease;
   background-color: var(--color-panel);
-  margin-bottom: -3px; /* Match the thicker border */
+  margin-bottom: -1px;
   z-index: 1;
 }
 
 .tab:not(.active) {
   opacity: 0.8;
-  border-bottom: 3px solid var(--color-border);
-  background-color: rgba(255, 255, 255, 0.03);
+  border-bottom-color: var(--color-border);
+  background-color: var(--color-panel);
 }
 
 .tab.active {
-  border-color: var(--color-border);
-  /* box-shadow:
-    0 -4px 8px -2px var(--color-border),
-    4px 0 8px -2px var(--color-border),
-    -4px 0 8px -2px var(--color-border); */
+  border-bottom-color: var(--color-primary);
   font-weight: bold;
-  background-color: var(--color-panel);
+  background-color: var(--color-background);
 }
 
 .light-mode .tab.active {


### PR DESCRIPTION
## Summary
- switch base font to Fira Code and set VS Code color palette
- refresh tab styling to mimic VS Code
- update component styles to use the new font
- add minimal Tailwind config with VS Code colors

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'attr')*

------
https://chatgpt.com/codex/tasks/task_e_68884254de1c83329b21b140551a3925